### PR TITLE
Fix captialization of RunloopQueue in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # RunloopQueue
 
-`RunLoopQueue` is a class for running code on a background thread. It works a *bit* like Grand Central Dispatch, but is instead powered by the magic of run loops! 
+`RunloopQueue` is a class for running code on a background thread. It works a *bit* like Grand Central Dispatch, but is instead powered by the magic of run loops! 
 
-`RunLoopQueue` works on both macOS and iOS.
+`RunloopQueue` works on both macOS and iOS.
 
 ```swift
 queue = RunloopQueue(named: "My Cool Queue")
@@ -15,15 +15,15 @@ queue.async {
 
 ### Usage
 
-To use `RunLoopQueue`, copy the `RunLoopQueue.swift` file to your project. You can also add `RunloopQueue+Streams.swift` and `RunloopQueue+URLConnection.swift` if you'd like the `Stream` and `URLConnection` helpers.
+To use `RunloopQueue`, copy the `RunloopQueue.swift` file to your project. You can also add `RunloopQueue+Streams.swift` and `RunloopQueue+URLConnection.swift` if you'd like the `Stream` and `URLConnection` helpers.
 
 ### Real-World Applications
 
-`RunLoopQueue` is currently being used in our Cascable family of apps, most notably in `CascableCore`, our SDK for working with WiFi-enabled cameras. `CascableCore` uses `RunLoopQueue` for managing connections with the cameras it supports, and scheduling messages back and forth. You can find out more about `CascableCore` in our [CascableCore Demo App](https://github.com/Cascable/cascablecore-demo).
+`RunloopQueue` is currently being used in our Cascable family of apps, most notably in `CascableCore`, our SDK for working with WiFi-enabled cameras. `CascableCore` uses `RunloopQueue` for managing connections with the cameras it supports, and scheduling messages back and forth. You can find out more about `CascableCore` in our [CascableCore Demo App](https://github.com/Cascable/cascablecore-demo).
 
 ### RunloopQueue vs. Grand Central Dispatch
 
-`RunLoopQueue` is *not* designed to be a replacement for Grand Central Dispatch. In fact, if you're performing the common flow of starting on the main thread, performing some background work then calling back to the main thread at the end of the operation to update UI, you'll need Grand Central Dispatch to get back to the main thread.
+`RunloopQueue` is *not* designed to be a replacement for Grand Central Dispatch. In fact, if you're performing the common flow of starting on the main thread, performing some background work then calling back to the main thread at the end of the operation to update UI, you'll need Grand Central Dispatch to get back to the main thread.
 
 ```swift
 queue.async {
@@ -36,21 +36,21 @@ queue.async {
 }
 ```
 
-However, `RunLoopQueue` does offer some advantages over Grand Central Dispatch in certain circumstances:
+However, `RunloopQueue` does offer some advantages over Grand Central Dispatch in certain circumstances:
 
 #### Thread Consistency
 
-`RunLoopQueue` guarantees that all operations on a given `RunLoopQueue` instance will be executed on the same thread, whether they're performed synchronously or asynchronously. This can be handy if you're interacting with a library that expects thread consistency.
+`RunloopQueue` guarantees that all operations on a given `RunloopQueue` instance will be executed on the same thread, whether they're performed synchronously or asynchronously. This can be handy if you're interacting with a library that expects thread consistency.
 
 #### Support For "Where Am I?" Checking
 
-`RunLoopQueue` provides the `isRunningOnQueue()` method for checking whether or not the code calling that method is running on the given `RunLoopQueue` instance's thread. 
+`RunloopQueue` provides the `isRunningOnQueue()` method for checking whether or not the code calling that method is running on the given `RunloopQueue` instance's thread. 
 
 #### Safe(er) Synchronous Operations
 
 Grand Central Dispatch is *very* unsafe when it comes to synchronous operations, and it's very easy to deadlock your code. Personally, it's so unsafe that I ban its use in any project that I have that sort of influence over. 
 
-`RunLoopQueue`, however, is much better in this regard. Thanks to the `isRunningOnQueue()` method, it can avoid deadlocks when synchronous operations start other synchronous operations:
+`RunloopQueue`, however, is much better in this regard. Thanks to the `isRunningOnQueue()` method, it can avoid deadlocks when synchronous operations start other synchronous operations:
 
 ```swift
 queue.sync {
@@ -65,7 +65,7 @@ Please note that as in *any* multithreaded environment, synchronous operations a
 
 #### Friendly to Streams and URL Connections
 
-If you're working with streams or `URLConnection` objects, `RunLoopQueue` provides convenience methods for enqueuing such objects on its background thread. This is great if you'd like to process your incoming data in the background:
+If you're working with streams or `URLConnection` objects, `RunloopQueue` provides convenience methods for enqueuing such objects on its background thread. This is great if you'd like to process your incoming data in the background:
 
 ```swift
 let input: InputStream = …
@@ -74,7 +74,7 @@ let output: OutputStream = …
 input.delegate = self
 output.delegate = self
 
-// Scheduling the streams on a RunLoopQueue will cause their 
+// Scheduling the streams on a RunloopQueue will cause their 
 // delegate methods to be called on a background thread.
 queue.schedule(input)
 queue.schedule(output)
@@ -85,7 +85,7 @@ output.open()
 
 ### Objective-C
 
-`RunLoopQueue` is written in Swift 3, but is fully compatible with Objective-C.
+`RunloopQueue` is written in Swift 3, but is fully compatible with Objective-C.
 
 ```objc
 self.runloopQueue = [[CBLRunloopQueue alloc] initWithName:@"My Cool Queue"];


### PR DESCRIPTION
Couldn't help but notice the capitalization of `RunloopQueue` was off in the README. These changes make it consistent with the class itself.